### PR TITLE
checkout the version including Dockerfile_devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The command below tells Docker to follow the instructions in the Dockerfile_devn
 
 ```
 # Checkout and build with the compute module enabled, so we can deploy contracts.
-git checkout v0.1.0
+git checkout 168d64f5b5bd5b998a171cd24bba5d405e3a8229
 
 docker build -f Dockerfile_devnet -t enigmadev .
 ```


### PR DESCRIPTION
The last commit tried to go back to Enigma with the compute module enabled, tag v0.1.0, but that excluded the dockerized dev environment.